### PR TITLE
chore(build): add -Dpie build option to create PIE executable

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,8 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const pie = b.option(bool, "pie", "Build a Position Independent Executable") orelse false;
+
     // manpages
     {
         var man_step = zzdoc.addManpageStep(b, .{
@@ -46,6 +48,8 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    exe.pie = pie;
+
     const opts = b.addOptions();
     const version_string = version(b) catch |err| {
         std.debug.print("{}", .{err});


### PR DESCRIPTION
Having the option to build PIE is useful for potential distro consumers. Hopefully you'll find it acceptable to add 😁