### PR TITLE
chore: add desktop file

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,6 +65,7 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(exe);
     b.installFile("docs/comlink.lua", "share/comlink/lua/comlink.lua");
+    b.installFile("contrib/comlink.desktop", "share/applications/comlink.desktop");
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());

--- a/contrib/comlink.desktop
+++ b/contrib/comlink.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+TryExec=comlink
+Exec=comlink
+Terminal=true
+Categories=Network;IRCClient;
+
+Name=comlink
+Comment=An experimental IRC client


### PR DESCRIPTION
Trying out comlink on a desktop, I immediately miss being able to start it from a launcher.

This PR adds a bare-minimum desktop file that allows it to be picked up by various launchers, with further work to be considered if we want to accept irc mime type etc.

(Tested on a simple desktop installation with Wayland (labwc) and the fuzzel launcher.)