### PR TITLE
README: add irctoday

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ zig build -Doptimize=ReleaseSafe --prefix ~/.local
 
 Configuration is loaded from `$HOME/.config/comlink/init.lua`
 
-Works best with `soju`. pico.sh runs a free instance of `soju` and has fantastic
-[documentation](https://pico.sh/irc) on how to get connected
+Works best with `soju`. [irctoday](https://irctoday.com) runs a paid instance of `soju`, and
+another paid alternative is [pico.sh](https://pico.sh/irc)
 
 ```lua
 local comlink = require("comlink")


### PR DESCRIPTION
pico.sh's bouncer service has become restricted, requiring a pico+ subscription to access. irctoday is a another bouncer service ran by contributors of soju and senpai.