### PR TITLE
fix: deinit on app error

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -129,6 +129,7 @@ pub const App = struct {
             .bg = null,
             .yellow = null,
         };
+        errdefer self.deinit();
 
         self.lua = try Lua.init(self.alloc);
         self.write_thread = try std.Thread.spawn(.{}, writeLoop, .{ self.alloc, &self.write_queue });


### PR DESCRIPTION
turns a 7000 line stacktrace to only one, simple stacktrace.